### PR TITLE
enable usage of asan on cml without halt on error

### DIFF
--- a/images/trustx-cml-initramfs.bbappend
+++ b/images/trustx-cml-initramfs.bbappend
@@ -9,4 +9,7 @@ PACKAGE_INSTALL += " \
 	perl-module-file-basename \
 	perl-module-file-glob \
 	tcpdump \
+	gcc-sanitizers \
+	util-linux \
+	binutils \
 "

--- a/images/trustx-core.bbappend
+++ b/images/trustx-core.bbappend
@@ -9,4 +9,7 @@ PACKAGE_INSTALL += " \
 	perl-module-file-basename \
 	perl-module-file-glob \
 	tcpdump \
+	gcc-sanitizers \
+	util-linux \
+	binutils \
 "

--- a/recipes-initscripts/cml-boot/cml-boot_%.bbappend
+++ b/recipes-initscripts/cml-boot/cml-boot_%.bbappend
@@ -4,8 +4,13 @@ SRC_URI += "\
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/files:"
 
 do_install_append () {
-	bbwarn "Patching /init script t mount 9p file systems during early boot"
+	bbwarn "Patching /init script to mount 9p file systems during early boot"
 
 	bbwarn "sed -i \$\| -f \"/data/cml/containers/00000000-0000-0000-0000-000000000000.conf\" |e cat ${TOPDIR}/../meta-tmedbg/recipes-initscripts/cml-boot/files/mnt_ext9pfs ${D}/init"
 	sed -i '\| -f \"/data/cml/containers/00000000-0000-0000-0000-000000000000.conf\" |e cat ${TOPDIR}/../meta-tmedbg/recipes-initscripts/cml-boot/files/mnt_ext9pfs' ${D}/init
+
+	sed -i '/^export.*/i export ASAN_OPTIONS=log_path=/data/logs/asan.log:halt_on_error=0' ${D}/init
+	sed -i 's/^cmld/LD_PRELOAD=libasan.so.5 cmld/' ${D}/init
+	sed -i 's/^scd/LD_PRELOAD=libasan.so.5 scd/' ${D}/init
+
 }

--- a/recipes-initscripts/cml-boot/files/mnt_ext9pfs
+++ b/recipes-initscripts/cml-boot/files/mnt_ext9pfs
@@ -4,18 +4,23 @@ echo "[initramfs] Mounting /data 9pfs"
 mount -t 9p -o trans=virtio,version=9p2000.L extdata /mnt
 sleep 2
 
-mkdir -p /data/cmld
+mkdir -p /data/extcmld
 echo "[initramfs] Mounting /data/cmld 9pfs"
-mount -t 9p -o trans=virtio,version=9p2000.L extcmld /data/cmld
+mount -t 9p -o trans=virtio,version=9p2000.L extcmld /data/extcmld
 
 echo "[initramfs] Mounting /data 9pfs"
 mount -t tmpfs tmpfs /data/logs
 
-if [ -f /data/cml/cmld ];then
-    cp -f /data/cmld/cmld /usr/sbin/cmld
+if [ -f /data/extcmld/cmld ];then
+    cp -f /data/extcmld/cmld /usr/sbin/cmld
     echo "[initramfs] Copied new cmld to /usr/sbin"
-    cp -f /data/cmld/control /usr/sbin/control
+fi
+if [ -f /data/extcmld/control ];then
+    cp -f /data/extcmld/control /usr/sbin/control
     echo "[initramfs] Copied new cmld to /usr/sbin"
-    sleep 1
+fi
+if [ -f /data/extcmld/scd ];then
+    cp -f /data/extcmld/scd /usr/sbin/scd
+    echo "[initramfs] Copied new scd to /usr/sbin"
 fi
 ####################################

--- a/recipes-trustx/cmld/files/tme-dbgflags.patch
+++ b/recipes-trustx/cmld/files/tme-dbgflags.patch
@@ -6,7 +6,7 @@ index 7308eed..e6a736e 100644
  
  LOCAL_CFLAGS += -I../include -pedantic -std=gnu99 -D _POSIX_C_SOURCE=200809L -D _XOPEN_SOURCE=700 -D _DEFAULT_SOURCE -O2
  LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -fPIC
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  .PHONY: all
  all: libcommon
@@ -27,7 +27,7 @@ index 4d7f037..9109018 100644
  
  LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -Icommon -DDEBUG_BUILD -O2
  LOCAL_CFLAGS += -pedantic -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  SRC_FILES := \
  	common/list.c \
@@ -48,7 +48,7 @@ index 9b03bc1..e659ba4 100644
  LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
  LOCAL_CFLAGS += -DDEBUG_BUILD
  LDLIBS := -lc -lprotobuf-c -lprotobuf-c-text -lselinux -Lcommon -lcommon -lutil
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  TRUSTME_HARDWARE := x86
  
@@ -69,7 +69,7 @@ index 495c1a2..4955f25 100644
  LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -pedantic -O2
  LOCAL_CFLAGS += -DDEBUG_BUILD
  LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  PROTO_SRC := \
  	attestation.pb-c.c
@@ -90,7 +90,7 @@ index 3bccff5..6a1cb48 100644
  LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -pedantic -O2
  LOCAL_CFLAGS += -DDEBUG_BUILD -DTPM_POSIX
  LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  SRC_FILES := \
  	common/list.c \
@@ -111,7 +111,7 @@ index 674e5f0..e56fab9 100644
  LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -pedantic -O2
  LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
  LOCAL_CFLAGS += -DDEBUG_BUILD
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  SRC_FILES := \
  	common/protobuf.c \
@@ -132,7 +132,7 @@ index 791d28b..19f3c72 100644
  LOCAL_CFLAGS := -std=gnu99 -I. -I.. -I../include -Icommon $(tss_cflags) -O2
  LOCAL_CFLAGS += -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
  #LOCAL_CFLAGS += -DTPM2D_NVMCRYPT_ONLY
-+LOCAL_CFLAGS += -g -fsanitize=address
++LOCAL_CFLAGS += -g -fsanitize=address -fsanitize-recover=address
  
  SRC_FILES := \
  	common/dir.c \


### PR DESCRIPTION
Enable usage of ASAN on cmld and scd without halt on error and activating it by default.